### PR TITLE
Fix default jekyll-org-post-template

### DIFF
--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -100,7 +100,7 @@
 The `'%s`' will be replaced respectively by name, the author, the generated date, the title, the description and the categories.")
 
 (setq org2jekyll/jekyll-org-post-template
-      "#+STARTUP: showall\n#+STARTUP: hidestars\n#+OPTIONS: H:2 num:nil tags:nil toc:nil timestamps:t\n#+LAYOUT: post\n#+AUTHOR: %s\n#+DATE: %s\n#+TITLE: %s\n#+DESCRIPTION: %s\n#+CATEGORIES: %s\n\n")
+      "#+STARTUP: showall\n#+STARTUP: hidestars\n#+OPTIONS: H:2 num:nil tags:nil toc:nil timestamps:t\n#+LAYOUT: %s\n#+AUTHOR: %s\n#+DATE: %s\n#+TITLE: %s\n#+DESCRIPTION: %s\n#+CATEGORIES: %s\n\n")
 
 (defun org2jekyll/--optional-folder (folder-source &optional folder-name)
   "Compute the folder name from a FOLDER-SOURCE and an optional FOLDER-NAME."


### PR DESCRIPTION
The first parameter of the function "org2jekyll/default-headers-template" got lost in the default "jekyll-org-post-template". This caused the values of the prompted properties to be assigned to the wrong org-mode property in the resulting draft file.