### PR TITLE
Collection support

### DIFF
--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -406,16 +406,23 @@ Otherwise, display the error messages about the missing mandatory values."
   "Publish ORG-FILE as a page."
   (org2jekyll-read-metadata-and-execute
    (lambda (org-metadata org-file)
-     (let ((blog-project (assoc-default "layout" org-metadata))
-           (backup-file (format "%s.org2jekyll" org-file)))
-       (copy-file org-file backup-file t t t)
-       (with-temp-file org-file
+     (let ((blog-project (assoc-default "type" org-metadata))
+           (jekyll-file (format "%s.org2jekyll" (file-name-sans-extension org-file))))
+       (with-temp-file jekyll-file
          (insert-file-contents org-file)
          (goto-char (point-min))
-         (insert (org2jekyll--to-yaml-header org-metadata))
-         (org-publish-file org-file (assoc blog-project org-publish-project-alist)))
-       (copy-file backup-file org-file t t t)
-       (delete-file backup-file)))
+         (insert (org2jekyll--to-yaml-header org-metadata)))
+       (org-publish-file jekyll-file
+                         (append
+                          ;; Redefine `:base-extension' to have correct exported
+                          ;; file name
+                          ;;
+                          ;; TODO `org2jekyll-create-draft' doesn't deal with
+                          ;; page correctly (due to the incompleteness of
+                          ;; collection support)
+                          `(,blog-project :base-extension "org2jekyll")
+                          (cdr (assoc blog-project org-publish-project-alist))))
+       (delete-file jekyll-file)))
    org-file))
 
 (defun org2jekyll-post-p (layout)

--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -93,6 +93,12 @@
   :require 'org2jekyll
   :group 'org2jekyll)
 
+(defcustom org2jekyll-jekyll-draft-user-types '()
+  "User types of drafts. Customize to include collections."
+  :type 'list
+  :require 'org2jekyll
+  :group 'org2jekyll)
+
 (defalias 'org2jekyll/jekyll-drafts-dir 'org2jekyll-jekyll-drafts-dir)
 
 (defcustom org2jekyll-jekyll-posts-dir nil
@@ -106,12 +112,21 @@
 (defvar org2jekyll-jekyll-post-ext ".org"
   "File extension of Jekyll posts.")
 
-(defvar org2jekyll-jekyll-org-post-template nil
+(defconst org2jekyll-jekyll-org-post-template
+"#+STARTUP: showall
+#+STARTUP: hidestars
+#+OPTIONS: H:2 num:nil tags:nil toc:nil timestamps:t
+#+TYPE: %s
+#+LAYOUT: %s
+#+AUTHOR: %s
+#+DATE: %s
+#+TITLE: %s
+#+DESCRIPTION: %s
+#+TAGS: %s
+#+CATEGORIES: %s
+\n"
   "Default template for org2jekyll draft posts.
 The `'%s`' will be replaced respectively by name, the author, the generated date, the title, the description and the categories.")
-
-(setq org2jekyll-jekyll-org-post-template
-      "#+STARTUP: showall\n#+STARTUP: hidestars\n#+OPTIONS: H:2 num:nil tags:nil toc:nil timestamps:t\n#+LAYOUT: %s\n#+AUTHOR: %s\n#+DATE: %s\n#+TITLE: %s\n#+DESCRIPTION: %s\n#+TAGS: %s\n#+CATEGORIES: %s\n\n")
 
 (defun org2jekyll--optional-folder (folder-source &optional folder-name)
   "Compute the folder name from a FOLDER-SOURCE and an optional FOLDER-NAME."
@@ -143,8 +158,9 @@ The `'%s`' will be replaced respectively by name, the author, the generated date
   "Generate a formatted now date."
   (format-time-string "%Y-%m-%d %a %H:%M"))
 
-(defun org2jekyll-default-headers-template (blog-layout blog-author post-date post-title post-description post-tags post-categories)
+(defun org2jekyll-default-headers-template (blog-type blog-layout blog-author post-date post-title post-description post-tags post-categories)
   "Compute default headers.
+BLOG-TYPE is the type of the post, linked with org porjects.
 BLOG-LAYOUT is the layout of the post.
 BLOG-AUTHOR is the author.
 POST-DATE is the date of the post.
@@ -152,7 +168,7 @@ POST-TITLE is the title.
 POST-DESCRIPTION is the description.
 POST-TAGS is the tags
 POST-CATEGORIES is the categories."
-  (format org2jekyll-jekyll-org-post-template blog-layout blog-author post-date (org2jekyll--yaml-escape post-title) post-description post-tags post-categories))
+  (format org2jekyll-jekyll-org-post-template blog-type blog-layout blog-author post-date (org2jekyll--yaml-escape post-title) post-description post-tags post-categories))
 
 (defun org2jekyll--draft-filename (draft-dir title)
   "Compute the draft's filename from the DRAFT-DIR and TITLE."
@@ -164,13 +180,19 @@ POST-CATEGORIES is the categories."
 The `'%s`' will be replaced respectively by the blog entry name, the author, the
  generated date, the title, the description, the tags and the categories."
   (interactive)
-  (let ((author      org2jekyll-blog-author)
-        (date        (org2jekyll-now))
-        (layout      (ido-completing-read "Layout: " '("post" "default") nil 'require-match))
-        (title       (read-string "Title: "))
-        (description (read-string "Description: "))
-        (tags        (read-string "Tags (csv): "))
-        (categories  (read-string "Categories (csv): ")))
+  (let* ((author      org2jekyll-blog-author)
+         (date        (org2jekyll-now))
+         (type      (ido-completing-read "Type: "
+                                         (append '("page" "post")
+                                                 org2jekyll-jekyll-draft-user-types)
+                                         nil 'require-match))
+         ;; hard-coded layouts, the general idea is that the user need to
+         ;; customize it on their own.
+         (layout    (if (string= type "page") "default" "post"))
+         (title       (read-string "Title: "))
+         (description (read-string "Description: "))
+         (tags        (read-string "Tags (csv): "))
+         (categories  (read-string "Categories (csv): ")))
     (let ((draft-file (org2jekyll--draft-filename (org2jekyll-input-directory org2jekyll-jekyll-drafts-dir) title)))
       (if (file-exists-p draft-file)
           (find-file draft-file)
@@ -236,7 +258,8 @@ Depends on the metadata header #+LAYOUT."
                               ("date"        . "date")
                               ("description" . "excerpt")
                               ("author"      . "author")
-                              ("layout"      . "layout"))
+                              ("layout"      . "layout")
+                              ("type"        . "collection"))
   "Keys to map from org headers to jekyll's headers.")
 
 (defun org2jekyll--org-to-yaml-metadata (org-metadata)
@@ -298,7 +321,8 @@ Return DEFAULT-VALUE if not found."
 (defvar org2jekyll-header-metadata nil
   "The needed headers for org buffer for org2jekyll to work.")
 
-(setq org2jekyll-header-metadata '(("title"       . 'mandatory)
+(setq org2jekyll-header-metadata '(("type"        . 'mandatory)
+                                   ("title"       . 'mandatory)
                                    ("date")
                                    ("categories"  . 'mandatory)
                                    ("tags")
@@ -326,7 +350,8 @@ Otherwise, display the error messages about the missing mandatory values."
          (org-metadata (org2jekyll-get-options-from-file org-file org-metadata-list)))
     (-if-let (error-messages (org2jekyll-check-metadata org-metadata))
         (format "This org-mode file is missing mandatory header(s):\n%s\nPublication skipped" error-messages)
-      `(("layout"      . ,(-> "layout"      (org2jekyll-assoc-default org-metadata "post")))
+      `(("type"        . ,(-> "type"        (org2jekyll-assoc-default org-metadata "post")))
+        ("layout"      . ,(-> "layout"      (org2jekyll-assoc-default org-metadata "post")))
         ("title"       . ,(-> "title"       (org2jekyll-assoc-default org-metadata "dummy-title-should-be-replaced")))
         ("date"        . ,(-> "date"        (org2jekyll-assoc-default org-metadata (org2jekyll-now)) org2jekyll--convert-timestamp-to-yyyy-dd-mm))
         ("categories"  . ,(-> "categories"  (org2jekyll-assoc-default org-metadata "dummy-category-should-be-replaced") org2jekyll--csv-to-yaml))
@@ -354,7 +379,7 @@ Otherwise, display the error messages about the missing mandatory values."
   "Publish ORG-FILE as a post."
   (org2jekyll-read-metadata-and-execute
    (lambda (org-metadata org-file)
-     (let ((blog-project    (assoc-default "layout" org-metadata))
+     (let ((blog-project    (assoc-default "type" org-metadata))
            (jekyll-filename (org2jekyll--copy-org-file-to-jekyll-org-file (assoc-default "date" org-metadata) org-file org-metadata)))
        (org-publish-file jekyll-filename (assoc blog-project org-publish-project-alist))
        (delete-file jekyll-filename)))


### PR DESCRIPTION
Jekyll has support for collections: http://jekyllrb.com/docs/collections/
It's very useful if I want to create a topic page that list posts from a specific collection.

I've implemented basic features to have org2jekyll support collections, which works for my limited usage.
Test cases have NOT been written yet. 

As I see, some big changes are needed. Particularly the way org2jekyll determine the type of posts from the layout is changed. I don't think I've exhausted all necessary changes.

I need your opinion on including this collection feature and advice for improvements.

Thanks.