### PR TITLE
rename utilities.el to org2jekyll-utilities.el

### DIFF
--- a/org2jekyll-utilities.el
+++ b/org2jekyll-utilities.el
@@ -1,4 +1,4 @@
-;;; utilities.el ---                                 -*- lexical-binding: t; -*-
+;;; org2jekyll-utilities.el ---                      -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015  Antoine R. Dumont
 
@@ -47,5 +47,5 @@ NB-LINES-FORWARD is the number of lines to get back to."
      ,body-test
      (buffer-substring-no-properties (point-min) (point-max))))
 
-(provide 'utilities)
-;;; utilities.el ends here
+(provide 'org2jekyll-utilities)
+;;; org2jekyll-utilities.el ends here

--- a/test/org2jekyll-utilities-test.el
+++ b/test/org2jekyll-utilities-test.el
@@ -1,4 +1,4 @@
-;;; utilities-test.el ---                            -*- lexical-binding: t; -*-
+;;; org2jekyll-utilities-test.el ---                 -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015  Antoine R. Dumont
 
@@ -24,7 +24,7 @@
 
 ;;; Code:
 
-(require 'utilities)
+(require 'org2jekyll-utilities)
 (require 'ert)
 
 (ert-deftest test-org2jekyll-tests-with-temp-buffer ()
@@ -50,5 +50,5 @@ line 3
                     (replace-regexp "line " "" nil (point-min) (point-max))))))
 
 
-(provide 'utilities-test)
-;;; utilities-test.el ends here
+(provide 'org2jekyll-utilities-test)
+;;; org2jekyll-utilities-test.el ends here


### PR DESCRIPTION
"utilities.el" is a bad name for a library because any other package might come with a library by that name.

Currently there are at least two packages that contain a `utilities.el` library: this and [org-trello
](https://github.com/org-trello/org-trello/issues/319). I hope both of them get fixed.