### PR TITLE
CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,16 @@
-language: emacs-lisp
-env:
-  global:
-    - PATH=$HOME/.cask/bin:$HOME/.evm/bin:$PATH
-  matrix:
-    # - EVM_EMACS=emacs-24.1-bin
-    # - EVM_EMACS=emacs-24.2-bin
-    - EVM_EMACS=emacs-24.3-bin
-    - EVM_EMACS=emacs-24.4-bin
-    - EVM_EMACS=emacs-24.5-bin
+language: generic
+sudo: false
+
 before_install:
-  # evm install
-  - curl -fsSkL https://gist.github.com/rejeep/7736123/raw > travis.sh && source ./travis.sh
-  # install the matrix's emacs version
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
   - evm install $EVM_EMACS --use --skip
-  - cask --version
-  - emacs --version
-  # install deps for cask
   - cask
+
+env:
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
+
 script:
-  - pwd
-  - make install test
+  - emacs --version
+  - make test

--- a/README.org
+++ b/README.org
@@ -1,8 +1,11 @@
 #+title: org2jekyll
 #+author: ardumont
 
-[[https://travis-ci.org/ardumont/org2jekyll][file:https://travis-ci.org/ardumont/org2jekyll.svg]]
-[[https://coveralls.io/r/ardumont/org2jekyll][file:https://coveralls.io/repos/ardumont/org2jekyll/badge.svg]]
+[[https://travis-ci.org/ardumont/org2jekyll][file:https://travis-ci.org/ardumont/org2jekyll.svg?branch=master]]
+[[https://coveralls.io/github/ardumont/org2jekyll?branch=master][file:https://coveralls.io/repos/github/ardumont/org2jekyll/badge.svg?branch=master]]
+[[https://melpa.org/#/org2jekyll][file:https://melpa.org/packages/org2jekyll-badge.svg]]
+[[https://stable.melpa.org/#/org2jekyll][file:https://stable.melpa.org/packages/org2jekyll-badge.svg]]
+[[https://www.gnu.org/licenses/gpl-2.0.txt][file:https://img.shields.io/:license-GPLv2-blue.svg]]
 
 Blogging with org-mode and jekyll without alien yaml headers.
 


### PR DESCRIPTION
Travis updates:
- Changed language from emacs-lisp to generic so that it passes validation in [Travis WebLint](https://lint.travis-ci.org/)
- Set sudo to false to explicitly send travis builds to Travis's new [container-based infrastructure](https://docs.travis-ci.com/user/workers/container-based-infrastructure/)
- Use new version of [evm](https://github.com/rejeep/evm#deprecation-warning) updated to support  [container-based infrastructure](https://docs.travis-ci.com/user/workers/container-based-infrastructure/)
- PATH env variables needed for cask and evm are already set in [travis-evm-cask.sh](https://gist.github.com/rejeep/ebcd57c3af83b049833b) allowing us to simplify by not having to specify PATH as a global env and take advantage of [defining multiple variables per item](https://docs.travis-ci.com/user/environment-variables/#Defining-Multiple-Variables-per-Item)

Badge updates:
- Set branch for travis and coveralls
- Added melpa, melpa-stable and license