### PR TITLE
Support the new org-mode export block syntax.

### DIFF
--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -347,14 +347,17 @@ Depends on the metadata header #+LAYOUT."
 
 (defun org2jekyll--to-yaml-header (org-metadata)
   "Given a list of ORG-METADATA, compute the yaml header string."
-  (--> org-metadata
-       org2jekyll--org-to-yaml-metadata
-       (--map (format "%s: %s" (car it) (cdr it)) it)
-       (cons "---" it)
-       (cons "#+BEGIN_EXPORT HTML" it)
-       (-snoc it "---")
-       (-snoc it "#+END_EXPORT\n")
-       (s-join "\n" it)))
+  (-let (((begin end) (if (string-lessp org-version "9.0")
+                          '("#+BEGIN_HTML" "#+END_HTML\n")
+                        '("#+BEGIN_EXPORT HTML" "#+END_EXPORT\n"))))
+    (--> org-metadata
+         org2jekyll--org-to-yaml-metadata
+         (--map (format "%s: %s" (car it) (cdr it)) it)
+         (cons "---" it)
+         (cons begin it)
+         (-snoc it "---")
+         (-snoc it end)
+         (s-join "\n" it))))
 
 (defun org2jekyll--csv-to-yaml (str-csv)
   "Transform a STR-CSV entries into a yaml entries."

--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -347,7 +347,11 @@ Depends on the metadata header #+LAYOUT."
 
 (defun org2jekyll--to-yaml-header (org-metadata)
   "Given a list of ORG-METADATA, compute the yaml header string."
-  (-let (((begin end) (if (string-lessp org-version "9.0")
+  ;; HACK: support both pre-9.0 and 9.0+ Org export block syntax. Instead of
+  ;; checking for the version, check for org-element-block-name-alist
+  ;; availability to detect pre-release 9.0 Git snapshots with the new syntax,
+  ;; see http://orgmode.org/cgit.cgi/org-mode.git/commit/?id=54318ad
+  (-let (((begin end) (if (boundp 'org-element-block-name-alist)
                           '("#+BEGIN_HTML" "#+END_HTML\n")
                         '("#+BEGIN_EXPORT HTML" "#+END_EXPORT\n"))))
     (--> org-metadata

--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -351,9 +351,9 @@ Depends on the metadata header #+LAYOUT."
        org2jekyll--org-to-yaml-metadata
        (--map (format "%s: %s" (car it) (cdr it)) it)
        (cons "---" it)
-       (cons "#+BEGIN_HTML" it)
+       (cons "#+BEGIN_EXPORT HTML" it)
        (-snoc it "---")
-       (-snoc it "#+END_HTML\n")
+       (-snoc it "#+END_EXPORT\n")
        (s-join "\n" it)))
 
 (defun org2jekyll--csv-to-yaml (str-csv)

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -78,7 +78,7 @@
   (should (equal "\n- jabber\n- emacs\n- gtalk\n- tools\n- authentication"  (org2jekyll--csv-to-yaml "jabber,emacs,gtalk,tools,authentication"))))
 
 (ert-deftest test-org2jekyll--to-yaml-header ()
-  (should (string= "#+BEGIN_EXPORT HTML
+  (should (string= "#+BEGIN_HTML
 ---
 layout: post
 title: gtalk in emacs using jabber mode
@@ -88,15 +88,36 @@ categories: \n- jabber\n- emacs\n- tools\n- gtalk
 tags: \n- tag0\n- tag1\n- tag2
 excerpt: Installing jabber and using it from emacs + authentication tips and tricks
 ---
+#+END_HTML
+"
+                   (let ((org-version "8.3"))
+                     (org2jekyll--to-yaml-header '(("layout" . "post")
+                                                   ("title" . "gtalk in emacs using jabber mode")
+                                                   ("date" . "2013-01-13")
+                                                   ("author" . "Antoine R. Dumont")
+                                                   ("categories" . "\n- jabber\n- emacs\n- tools\n- gtalk")
+                                                   ("tags"  . "\n- tag0\n- tag1\n- tag2")
+                                                   ("description" . "Installing jabber and using it from emacs + authentication tips and tricks"))))))
+  (should (string= "#+BEGIN_EXPORT HTML
+---
+layout: post
+title: gtalk in emacs using jabber mode
+date: 2013-01-13
+author: Alexey Kopytov
+categories: \n- jabber\n- emacs\n- tools\n- gtalk
+tags: \n- tag0\n- tag1\n- tag2
+excerpt: Installing jabber and using it from emacs + authentication tips and tricks
+---
 #+END_EXPORT
 "
-                   (org2jekyll--to-yaml-header '(("layout" . "post")
-                                                 ("title" . "gtalk in emacs using jabber mode")
-                                                 ("date" . "2013-01-13")
-                                                 ("author" . "Antoine R. Dumont")
-                                                 ("categories" . "\n- jabber\n- emacs\n- tools\n- gtalk")
-                                                 ("tags"  . "\n- tag0\n- tag1\n- tag2")
-                                                 ("description" . "Installing jabber and using it from emacs + authentication tips and tricks"))))))
+                   (let ((org-version "9.0"))
+                     (org2jekyll--to-yaml-header '(("layout" . "post")
+                                                   ("title" . "gtalk in emacs using jabber mode")
+                                                   ("date" . "2013-01-13")
+                                                   ("author" . "Alexey Kopytov")
+                                                   ("categories" . "\n- jabber\n- emacs\n- tools\n- gtalk")
+                                                   ("tags"  . "\n- tag0\n- tag1\n- tag2")
+                                                   ("description" . "Installing jabber and using it from emacs + authentication tips and tricks")))))))
 
 (ert-deftest test-org2jekyll--org-to-yaml-metadata ()
   (should (equal '(("layout" . "post")
@@ -126,7 +147,7 @@ excerpt: Installing jabber and using it from emacs + authentication tips and tri
 
 (require 'el-mock)
 (ert-deftest test-org2jekyll--copy-org-file-to-jekyll-org-file ()
-  (should (equal "#+BEGIN_EXPORT
+  (should (equal "#+BEGIN_HTML
 ---
 layout: post
 title: some fake title
@@ -135,12 +156,13 @@ categories: \n- some-fake-category1\n- some-fake-category2
 author: some-fake-author
 excerpt: some-fake-description with spaces and all
 ---
-#+END_EXPORT
+#+END_HTML
 #+fake-meta: some fake meta
 * some content"
                  (let ((fake-date            "2012-10-10")
                        (fake-org-file        "/tmp/scratch.org")
-                       (fake-org-jekyll-file "/tmp/fake-org-jekyll.org"))
+                       (fake-org-jekyll-file "/tmp/fake-org-jekyll.org")
+                       (org-version          "8.2.10"))
                    ;; @before
                    (when (file-exists-p fake-org-file) (delete-file fake-org-file))
                    (when (file-exists-p fake-org-jekyll-file) (delete-file fake-org-jekyll-file))
@@ -157,6 +179,40 @@ excerpt: some-fake-description with spaces and all
                                                                                        ("categories"  . "\n- some-fake-category1\n- some-fake-category2")
                                                                                        ("author"      . "some-fake-author")
                                                                                        ("description" . "some-fake-description with spaces and all")))
+                          (insert-file-contents it)
+                          (with-temp-buffer it (buffer-string)))))))
+  (should (equal "#+BEGIN_EXPORT HTML
+---
+layout: post
+title: fake title
+date: 2016-02-28
+categories: \n- fake-category1\n- fake-category2
+author: fake-author
+excerpt: fake-description with spaces and all
+---
+#+END_EXPORT
+#+fake-meta: fake meta
+* some content"
+                 (let ((fake-date            "2016-02-28")
+                       (fake-org-file        "/tmp/scratch-9.0.org")
+                       (fake-org-jekyll-file "/tmp/fake-org-jekyll-9.0.org")
+                       (org-version          "9.0"))
+                   ;; @before
+                   (when (file-exists-p fake-org-file) (delete-file fake-org-file))
+                   (when (file-exists-p fake-org-jekyll-file) (delete-file fake-org-jekyll-file))
+                   ;; @Test
+                   (mocklet (((org2jekyll--compute-ready-jekyll-file-name fake-date fake-org-file) => fake-org-jekyll-file))
+                     ;; create fake org file with some default content
+                     (with-temp-file fake-org-file
+                       (insert "#+fake-meta: fake meta\n* some content"))
+                     ;; create the fake jekyll file with jekyll metadata
+                     (--> fake-org-file
+                          (org2jekyll--copy-org-file-to-jekyll-org-file fake-date it `(("layout"      . "post")
+                                                                                       ("title"       . "fake title")
+                                                                                       ("date"        . ,fake-date)
+                                                                                       ("categories"  . "\n- fake-category1\n- fake-category2")
+                                                                                       ("author"      . "fake-author")
+                                                                                       ("description" . "fake-description with spaces and all")))
                           (insert-file-contents it)
                           (with-temp-buffer it (buffer-string))))))))
 

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -78,7 +78,7 @@
   (should (equal "\n- jabber\n- emacs\n- gtalk\n- tools\n- authentication"  (org2jekyll--csv-to-yaml "jabber,emacs,gtalk,tools,authentication"))))
 
 (ert-deftest test-org2jekyll--to-yaml-header ()
-  (should (string= "#+BEGIN_HTML
+  (should (string= "#+BEGIN_EXPORT HTML
 ---
 layout: post
 title: gtalk in emacs using jabber mode
@@ -88,7 +88,7 @@ categories: \n- jabber\n- emacs\n- tools\n- gtalk
 tags: \n- tag0\n- tag1\n- tag2
 excerpt: Installing jabber and using it from emacs + authentication tips and tricks
 ---
-#+END_HTML
+#+END_EXPORT
 "
                    (org2jekyll--to-yaml-header '(("layout" . "post")
                                                  ("title" . "gtalk in emacs using jabber mode")
@@ -126,7 +126,7 @@ excerpt: Installing jabber and using it from emacs + authentication tips and tri
 
 (require 'el-mock)
 (ert-deftest test-org2jekyll--copy-org-file-to-jekyll-org-file ()
-  (should (equal "#+BEGIN_HTML
+  (should (equal "#+BEGIN_EXPORT
 ---
 layout: post
 title: some fake title
@@ -135,7 +135,7 @@ categories: \n- some-fake-category1\n- some-fake-category2
 author: some-fake-author
 excerpt: some-fake-description with spaces and all
 ---
-#+END_HTML
+#+END_EXPORT
 #+fake-meta: some fake meta
 * some content"
                  (let ((fake-date            "2012-10-10")

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -78,6 +78,7 @@
   (should (equal "\n- jabber\n- emacs\n- gtalk\n- tools\n- authentication"  (org2jekyll--csv-to-yaml "jabber,emacs,gtalk,tools,authentication"))))
 
 (ert-deftest test-org2jekyll--to-yaml-header ()
+  ;; pre-9.0 Org releases
   (should (string= "#+BEGIN_HTML
 ---
 layout: post
@@ -90,7 +91,7 @@ excerpt: Installing jabber and using it from emacs + authentication tips and tri
 ---
 #+END_HTML
 "
-                   (let ((org-version "8.3"))
+                   (mocklet (((boundp 'org-element-block-name-alist) => t))
                      (org2jekyll--to-yaml-header '(("layout" . "post")
                                                    ("title" . "gtalk in emacs using jabber mode")
                                                    ("date" . "2013-01-13")
@@ -98,6 +99,7 @@ excerpt: Installing jabber and using it from emacs + authentication tips and tri
                                                    ("categories" . "\n- jabber\n- emacs\n- tools\n- gtalk")
                                                    ("tags"  . "\n- tag0\n- tag1\n- tag2")
                                                    ("description" . "Installing jabber and using it from emacs + authentication tips and tricks"))))))
+  ;; Org 9.0+ and org 8.3.x git snapshots
   (should (string= "#+BEGIN_EXPORT HTML
 ---
 layout: post
@@ -110,7 +112,7 @@ excerpt: Installing jabber and using it from emacs + authentication tips and tri
 ---
 #+END_EXPORT
 "
-                   (let ((org-version "9.0"))
+                   (mocklet (((boundp 'org-element-block-name-alist) => nil))
                      (org2jekyll--to-yaml-header '(("layout" . "post")
                                                    ("title" . "gtalk in emacs using jabber mode")
                                                    ("date" . "2013-01-13")
@@ -147,6 +149,7 @@ excerpt: Installing jabber and using it from emacs + authentication tips and tri
 
 (require 'el-mock)
 (ert-deftest test-org2jekyll--copy-org-file-to-jekyll-org-file ()
+  ; pre-9.0 Org releases
   (should (equal "#+BEGIN_HTML
 ---
 layout: post
@@ -161,13 +164,13 @@ excerpt: some-fake-description with spaces and all
 * some content"
                  (let ((fake-date            "2012-10-10")
                        (fake-org-file        "/tmp/scratch.org")
-                       (fake-org-jekyll-file "/tmp/fake-org-jekyll.org")
-                       (org-version          "8.2.10"))
+                       (fake-org-jekyll-file "/tmp/fake-org-jekyll.org"))
                    ;; @before
                    (when (file-exists-p fake-org-file) (delete-file fake-org-file))
                    (when (file-exists-p fake-org-jekyll-file) (delete-file fake-org-jekyll-file))
                    ;; @Test
-                   (mocklet (((org2jekyll--compute-ready-jekyll-file-name fake-date fake-org-file) => fake-org-jekyll-file))
+                   (mocklet (((boundp 'org-element-block-name-alist) => t)
+                     ((org2jekyll--compute-ready-jekyll-file-name fake-date fake-org-file) => fake-org-jekyll-file))
                      ;; create fake org file with some default content
                      (with-temp-file fake-org-file
                        (insert "#+fake-meta: some fake meta\n* some content"))
@@ -181,6 +184,7 @@ excerpt: some-fake-description with spaces and all
                                                                                        ("description" . "some-fake-description with spaces and all")))
                           (insert-file-contents it)
                           (with-temp-buffer it (buffer-string)))))))
+  ; Org 9.0+ and org 8.3.x git snapshots
   (should (equal "#+BEGIN_EXPORT HTML
 ---
 layout: post
@@ -195,13 +199,13 @@ excerpt: fake-description with spaces and all
 * some content"
                  (let ((fake-date            "2016-02-28")
                        (fake-org-file        "/tmp/scratch-9.0.org")
-                       (fake-org-jekyll-file "/tmp/fake-org-jekyll-9.0.org")
-                       (org-version          "9.0"))
+                       (fake-org-jekyll-file "/tmp/fake-org-jekyll-9.0.org"))
                    ;; @before
                    (when (file-exists-p fake-org-file) (delete-file fake-org-file))
                    (when (file-exists-p fake-org-jekyll-file) (delete-file fake-org-jekyll-file))
                    ;; @Test
-                   (mocklet (((org2jekyll--compute-ready-jekyll-file-name fake-date fake-org-file) => fake-org-jekyll-file))
+                   (mocklet (((boundp 'org-element-block-name-alist) => nil)
+                     ((org2jekyll--compute-ready-jekyll-file-name fake-date fake-org-file) => fake-org-jekyll-file))
                      ;; create fake org file with some default content
                      (with-temp-file fake-org-file
                        (insert "#+fake-meta: fake meta\n* some content"))


### PR DESCRIPTION
org-mode Git HEAD has a different export block syntax, which will be released in Org 9.0.

Instead of `#+BEGIN_HTML` / `#+END_HTML`, `#+BEGIN_EXPORT HTML` / `#+END_EXPORT` should be used, see https://www.mail-archive.com/emacs-orgmode@gnu.org/msg102960.html

The old syntax is still supported, but results in the YAML header being wrapped into the `<div class="HTML">` tag and all non-HTML symbols being quoted, which breaks the page layout.

Not sure how to handle older Org versions, and you likely have a better idea on how to fix this properly.
