### PR TITLE
Add Previews section, change compulse to compile

### DIFF
--- a/README.org
+++ b/README.org
@@ -239,13 +239,18 @@ When ready, /M-x org2jekyll-publish/ to publish it.
 
 /M-x org2jekyll-publish-posts/
 
-Depending on your org-publish configuration and org2jekll, this will compulse the list of org-mode posts (*#+LAYOUT* with 'post' value) and publish them.
+Depending on your org-publish configuration and org2jekll, this will compile the list of org-mode posts (*#+LAYOUT* with 'post' value) and publish them.
 
 ** Publish all pages
 
 /M-x org2jekyll-publish-pages/
 
-Depending on your org-publish configuration and org2jekll, this will compulse the list of org-mode pages (*#+LAYOUT* with 'default value) and publish them.
+Depending on your org-publish configuration and org2jekll, this will compile the list of org-mode pages (*#+LAYOUT* with 'default value) and publish them.
+
+** Previews
+
+You can keep an org file in your blog directory without publishing it, by writing it as a plain org file without the org2jekyll headers. Once you're ready
+to publish it as a post or an article, add the appropriate metadata headers and org2jekyll will now publish the file.
 
 * Minor mode
 

--- a/README.org
+++ b/README.org
@@ -58,7 +58,7 @@ Only emacs' dependencies (org, etc...) no external ruby script.
 - [[http://orgmode.org/][org-mode]] rocks
 - Github uses [[http://jekyllrb.com/][Jekyll]]
 - [[http://jekyllrb.com/][Jekyll]] is nice
-- Existing solutions regarding org-mode and jekyll needs the org-mode files to be altered with non-org notations to work together
+- Existing solutions regarding org-mode and jekyll need the org-mode files to be altered with non-org notations to work together
 - I don't want to alter my org-mode files with alien yaml headers to satisfy jekyll
 
 Enters org2jekyll.
@@ -239,13 +239,13 @@ When ready, /M-x org2jekyll-publish/ to publish it.
 
 /M-x org2jekyll-publish-posts/
 
-Depending on your org-publish configuration and org2jekll, this will compile the list of org-mode posts (*#+LAYOUT* with 'post' value) and publish them.
+Depending on your org-publish configuration and org2jekyll, this will compile the list of org-mode posts (*#+LAYOUT* with 'post' value) and publish them.
 
 ** Publish all pages
 
 /M-x org2jekyll-publish-pages/
 
-Depending on your org-publish configuration and org2jekll, this will compile the list of org-mode pages (*#+LAYOUT* with 'default value) and publish them.
+Depending on your org-publish configuration and org2jekyll, this will compile the list of org-mode pages (*#+LAYOUT* with 'default value) and publish them.
 
 ** Previews
 
@@ -254,7 +254,7 @@ to publish it as a post or an article, add the appropriate metadata headers and 
 
 * Minor mode
 
-org2jekyll proposes you a minor with the following default binding:
+org2jekyll provides you a minor mode with the following default binding:
 #+begin_src emacs-lisp
 (setq org2jekyll-mode-map
       (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
I think it would be helpful to describe how to have articles or pages in the blog directory that won't get published until they are ready, since that capabilty now exists. I use "preview" instead of "draft" because org2jekyll drafts seem to be different from jeykll drafts.
I also changed "compulse" to "compile", as that seems to fit the meaning of the sentence better.

Thanks again
Bob