### PR TITLE
0.1.9

### DIFF
--- a/README.org
+++ b/README.org
@@ -11,28 +11,35 @@ Blogging with org-mode and jekyll without alien yaml headers.
 
 * Table of Contents                                                     :TOC_4:
  - [[#upgrade][Upgrade]]
-     - [[#012---014][0.1.2 -> 0.1.4]]
+   - [[#018---019][0.1.8 -> 0.1.9]]
+   - [[#012---014][0.1.2 -> 0.1.4]]
  - [[#description][Description]]
-     - [[#rationale][Rationale]]
-     - [[#pre-requisite][Pre-requisite]]
+   - [[#rationale][Rationale]]
+   - [[#pre-requisite][Pre-requisite]]
  - [[#installsetup][Install/Setup]]
-     - [[#install][Install]]
-     - [[#setup][Setup]]
-     - [[#a-working-example][A working example]]
+   - [[#install][Install]]
+   - [[#setup][Setup]]
+   - [[#a-working-example][A working example]]
  - [[#use][Use]]
-     - [[#post][Post]]
-         - [[#headers][Headers]]
-         - [[#publish][Publish]]
-         - [[#how][How]]
-     - [[#page][Page]]
-         - [[#headers][Headers]]
-         - [[#publish][Publish]]
-         - [[#how][How]]
-     - [[#publish-all-posts][Publish all posts]]
-     - [[#publish-all-pages][Publish all pages]]
+   - [[#post][Post]]
+     - [[#headers][Headers]]
+     - [[#publish][Publish]]
+     - [[#how][How]]
+     - [[#optional][Optional]]
+   - [[#page][Page]]
+     - [[#headers][Headers]]
+     - [[#publish][Publish]]
+     - [[#how][How]]
+   - [[#publish-all-posts][Publish all posts]]
+   - [[#publish-all-pages][Publish all pages]]
+   - [[#previews][Previews]]
  - [[#minor-mode][Minor mode]]
 
 * Upgrade
+
+** 0.1.8 -> 0.1.9
+- Remove deprecated api function names mentioned in 0.1.2 -> 0.1.4 migration.
+- Permit user to define on per-buffer setup or per-custom variable basis some extra yaml header
 
 ** 0.1.2 -> 0.1.4
 
@@ -184,6 +191,7 @@ For a post (layout 'post'):
 #+TITLE: hello
 #+DESCRIPTION: some description
 #+CATEGORIES: category0, category1
+#+EXTRA-YAML-HEADERS: theme: blah\nplugin: lightense\nscheme-hover: \"#ff00b4\"
 #+end_src
 
 *Note*
@@ -202,6 +210,22 @@ This will be published as post article.
 - The *#+LAYOUT* entry refers to the *post* entry in *org-publish-project-alist*.
 - This will create another temporary org-mode file based on the current one with the right naming convention, transform the org headers into yaml, publish to the jekyll directory (according to your org-publish setup) and delete the temporary file.
 
+*** Optional
+
+As in issue https://github.com/ardumont/org2jekyll/issues/36, you
+could have the need to add some extra yaml headers.  To add such, you
+can either use the buffer option *EXTRA-YAML-HEADERS* (as in previous
+sample) or define a global user custom
+`org2jekyll-extra-yaml-headers`.
+
+
+#+BEGIN_SRC emacs-lisp
+(custom-set-variables '(org2jekyll-extra-yaml-headers "theme: blah\nplugin: lightense\nscheme-hover: \"#ff00b4\""))
+#+END_SRC
+
+The buffer option has priority over the user custom. That is, if you
+define both, it's the buffer one which take precedence.
+
 ** Page
 
 *** Headers
@@ -218,6 +242,7 @@ For a page (layout 'default').
 #+TITLE: hello
 #+DESCRIPTION: some description
 #+CATEGORIES: some-category
+#+EXTRA-YAML-HEADERS: theme: blah\nplugin: lightense\nscheme-hover: \"#ff00b4\"
 #+end_src
 
 *Note*

--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -367,17 +367,24 @@ Depends on the metadata header #+LAYOUT."
   ;; see http://orgmode.org/cgit.cgi/org-mode.git/commit/?id=54318ad
   (boundp 'org-element-block-name-alist))
 
+(defun org2jekyll--read-extra-yaml-headers ()
+  "Compute extra-yaml-headers from current buffer."
+  (-if-let (extra-headers (org2jekyll-get-option "extra-yaml-headers"))
+      (s-replace "\\n" "\n" extra-headers)
+    org2jekyll-extra-yaml-headers))
+
 (defun org2jekyll--to-yaml-header (org-metadata)
   "Given a list of ORG-METADATA, compute the yaml header string."
   (-let (((begin end) (if (org2jekyll--old-org-version-p)
                           '("#+BEGIN_HTML" "#+END_HTML\n")
-                        '("#+BEGIN_EXPORT HTML" "#+END_EXPORT\n"))))
+                        '("#+BEGIN_EXPORT HTML" "#+END_EXPORT\n")))
+         (extra-headers (org2jekyll--read-extra-yaml-headers)))
     (--> org-metadata
          org2jekyll--org-to-yaml-metadata
          (--map (format "%s: %s" (car it) (cdr it)) it)
          (cons "---" it)
          (cons begin it)
-         (-snoc it org2jekyll-extra-yaml-headers)
+         (-snoc it extra-headers)
          (-snoc it "---")
          (-snoc it end)
          (s-join "\n" it)

--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -525,7 +525,7 @@ Publication skipped" error-messages)
    'org2jekyll--publish-post-org-file-with-metadata
    org-file))
 
-(defun org2ekyll--publish-page-org-file-with-metadata (org-metadata org-file)
+(defun org2jekyll--publish-page-org-file-with-metadata (org-metadata org-file)
   "Publish as page with ORG-METADATA the ORG-FILE."
   (let* ((blog-project (assoc-default "layout" org-metadata))
          (ext (file-name-extension org-file))
@@ -543,7 +543,7 @@ Publication skipped" error-messages)
 (defun org2jekyll-publish-page (org-file)
   "Publish ORG-FILE as a page."
   (org2jekyll-read-metadata-and-execute
-   'org2ekyll--publish-page-org-file-with-metadata
+   'org2jekyll--publish-page-org-file-with-metadata
    org-file))
 
 (defun org2jekyll-post-p (layout)

--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -69,15 +69,11 @@
   :require 'org2jekyll
   :group 'org2jekyll)
 
-(defalias 'org2jekyll/blog-author 'org2jekyll-blog-author) ;; for compatibility
-
 (defcustom org2jekyll-source-directory nil
   "Path to the source directory."
   :type 'string
   :require 'org2jekyll
   :group 'org2jekyll)
-
-(defalias 'org2jekyll/source-directory 'org2jekyll-source-directory)
 
 (defcustom org2jekyll-jekyll-directory nil
   "Path to Jekyll blog."
@@ -85,23 +81,17 @@
   :require 'org2jekyll
   :group 'org2jekyll)
 
-(defalias 'org2jekyll/jekyll-directory 'org2jekyll-jekyll-directory)
-
 (defcustom org2jekyll-jekyll-drafts-dir nil
   "Relative path to drafts directory."
   :type 'string
   :require 'org2jekyll
   :group 'org2jekyll)
 
-(defalias 'org2jekyll/jekyll-drafts-dir 'org2jekyll-jekyll-drafts-dir)
-
 (defcustom org2jekyll-jekyll-posts-dir nil
   "Relative path to posts directory."
   :type 'string
   :require 'org2jekyll
   :group 'org2jekyll)
-
-(defalias 'org2jekyll/jekyll-posts-dir 'org2jekyll-jekyll-posts-dir)
 
 (defcustom org2jekyll-extra-yaml-headers nil
   "An entry of static yaml header (already formatted).
@@ -282,8 +272,6 @@ The `'%s`' will be replaced respectively by the blog entry name, the author, the
         (insert "* ")))
     (find-file draft-file)))
 
-(defalias 'org2jekyll/create-draft! 'org2jekyll-create-draft)
-
 (defun org2jekyll--list-dir (dir)
   "List the content of DIR."
   (find-file dir))
@@ -295,16 +283,12 @@ The `'%s`' will be replaced respectively by the blog entry name, the author, the
   (org2jekyll--list-dir
    (org2jekyll-output-directory org2jekyll-jekyll-posts-dir)))
 
-(defalias 'org2jekyll/list-posts 'org2jekyll-list-posts)
-
 ;;;###autoload
 (defun org2jekyll-list-drafts ()
   "List the drafts folder."
   (interactive)
   (org2jekyll--list-dir
    (org2jekyll-input-directory org2jekyll-jekyll-drafts-dir)))
-
-(defalias 'org2jekyll/list-drafts 'org2jekyll-list-drafts)
 
 (defun org2jekyll-get-option (opt)
   "Gets the header value of the option OPT from a buffer."
@@ -580,8 +564,6 @@ Layout `'default`' is a page."
       (deferred:nextc it (lambda (final-message)
                            (org2jekyll-message final-message))))))
 
-(defalias 'org2jekyll/publish! 'org2jekyll-publish)
-
 (defvar org2jekyll-mode-map nil "Default Bindings map for org2jekyll mode.")
 
 (setq org2jekyll-mode-map
@@ -606,8 +588,6 @@ Layout `'default`' is a page."
       (lambda (posts)
         (mapc #'org2jekyll-publish-post posts)))))
 
-(defalias 'org2jekyll/publish-posts! 'org2jekyll-publish-posts)
-
 ;;;###autoload
 (defun org2jekyll-publish-pages ()
   "Publish all the pages."
@@ -620,8 +600,6 @@ Layout `'default`' is a page."
     (deferred:nextc it
       (lambda (pages)
         (mapc #'org2jekyll-publish-page pages)))))
-
-(defalias 'org2jekyll/publish-pages! 'org2jekyll-publish-pages)
 
 ;;;###autoload
 (define-minor-mode org2jekyll-mode

--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -1,6 +1,6 @@
 ;;; org2jekyll.el --- Minor mode to publish org-mode post to jekyll without specific yaml
 
-;; Copyright (C) 2014 Antoine R. Dumont <eniotna.t AT gmail.com>
+;; Copyright (C) 2014-2016 Antoine R. Dumont <eniotna.t AT gmail.com>
 
 ;; Author: Antoine R. Dumont <eniotna.t AT gmail.com>
 ;; Maintainer: Antoine R. Dumont <eniotna.t AT gmail.com>

--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -4,7 +4,7 @@
 
 ;; Author: Antoine R. Dumont <eniotna.t AT gmail.com>
 ;; Maintainer: Antoine R. Dumont <eniotna.t AT gmail.com>
-;; Version: 0.1.8
+;; Version: 0.1.9
 ;; Package-Requires: ((dash-functional "2.11.0") (s "1.9.0") (deferred "0.3.1"))
 ;; Keywords: org-mode jekyll blog publish
 ;; URL: https://github.com/ardumont/org2jekyll

--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -103,6 +103,20 @@
 
 (defalias 'org2jekyll/jekyll-posts-dir 'org2jekyll-jekyll-posts-dir)
 
+(defcustom org2jekyll-extra-yaml-headers nil
+  "An entry of static yaml header (already formatted).
+E.g. from https://github.com/ardumont/org2jekyll/issues/34#issue-148684715:
+scheme-text: \"#0029ff\"
+scheme-link: \"#ff00b4\"
+scheme-hover: \"#ff00b4\"
+scheme-code: \"#ad00ff\"
+scheme-bg: \"#00ebff\"
+scheme-hero-text: \"#00ebff\"
+scheme-hero-link: \"#00ebff\"
+scheme-hero-bg: \"#0029ff\"
+plugin: lightense"
+  :group 'org2jekyll)
+
 (defvar org2jekyll-jekyll-post-ext ".org"
   "File extension of Jekyll posts.")
 
@@ -363,9 +377,11 @@ Depends on the metadata header #+LAYOUT."
          (--map (format "%s: %s" (car it) (cdr it)) it)
          (cons "---" it)
          (cons begin it)
+         (-snoc it org2jekyll-extra-yaml-headers)
          (-snoc it "---")
          (-snoc it end)
-         (s-join "\n" it))))
+         (s-join "\n" it)
+         (s-replace "\n\n" "\n" it))))
 
 (defun org2jekyll--csv-to-yaml (str-csv)
   "Transform a STR-CSV entries into a yaml entries."

--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -306,7 +306,7 @@ The `'%s`' will be replaced respectively by the blog entry name, the author, the
 
 (defalias 'org2jekyll/list-drafts 'org2jekyll-list-drafts)
 
-(defun org2jekyll-get-option-at-point (opt)
+(defun org2jekyll-get-option (opt)
   "Gets the header value of the option OPT from a buffer."
   (let* ((regexp (org-make-options-regexp (list (upcase opt) (downcase opt)))))
     (save-excursion
@@ -320,7 +320,7 @@ The `'%s`' will be replaced respectively by the blog entry name, the author, the
     (when (file-exists-p orgfile)
       (insert-file-contents orgfile)
       (goto-char (point-min))
-      (org2jekyll-get-option-at-point option))))
+      (org2jekyll-get-option option))))
 
 (defun org2jekyll-get-options-from-file (orgfile options)
   "Return the ORGFILE's OPTIONS."
@@ -330,7 +330,7 @@ The `'%s`' will be replaced respectively by the blog entry name, the author, the
       (mapcar (lambda (option)
                 (save-excursion
                   (goto-char (point-min))
-                  (cons option (org2jekyll-get-option-at-point option))))
+                  (cons option (org2jekyll-get-option option))))
               options))))
 
 (defun org2jekyll-layout (org-file)
@@ -562,7 +562,7 @@ Layout `'default`' is a page."
     (deferred:$
       (deferred:next (lambda ()
                        (-> "layout"
-                           org2jekyll-get-option-at-point
+                           org2jekyll-get-option
                            org2jekyll-post-p
                            (if 'org2jekyll-publish-post
                                'org2jekyll-publish-page))))

--- a/release.sh
+++ b/release.sh
@@ -23,7 +23,7 @@ git checkout master
 
 git merge origin/master
 
-git tag $VERSION
+git tag -a -s $VERSION
 
 git push origin --tag
 

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -141,10 +141,11 @@ categories: \n- jabber\n- emacs\n- tools\n- gtalk
 tags: \n- tag0\n- tag1\n- tag2
 excerpt: Installing jabber and using it from emacs + authentication tips and tricks
 theme: blah
+plugin: light
 ---
 #+END_HTML
 "
-                   (let ((org2jekyll-extra-yaml-headers "theme: blah"))
+                   (let ((org2jekyll-extra-yaml-headers "theme: blah\nplugin: light"))
                      (mocklet (((org2jekyll--old-org-version-p) => t))
                        (org2jekyll--to-yaml-header '(("layout" . "post")
                                                      ("title" . "gtalk in emacs using jabber mode")
@@ -616,3 +617,36 @@ Publication skipped"
                        'org2ekyll--publish-page-org-file-with-metadata
                        :org-file) => :publish-page-done)
                 (org2jekyll-publish-page :org-file)))))
+
+(ert-deftest test-org2jekyll--read-extra-yaml-headers ()
+  (should (string= "theme: dark\nplugin: light"
+                   (org2jekyll-tests-with-temp-buffer
+                    "#+extra-yaml-headers: theme: dark\nplugin: light"
+                    (org2jekyll--read-extra-yaml-headers)))))
+
+(ert-deftest test-org2jekyll--read-extra-yaml-headers ()
+  (should (string= "theme: dark"
+                   (org2jekyll-tests-with-temp-buffer
+                    "#+title: hello
+#+extra-yaml-headers: theme: dark
+* one description"
+                    (org2jekyll--read-extra-yaml-headers))))
+  (should-not (org2jekyll-tests-with-temp-buffer
+               "#+title: hello
+* one description"
+               (org2jekyll--read-extra-yaml-headers))))
+
+(ert-deftest test-org2jekyll--read-extra-yaml-headers-2 ()
+  (should (string= "theme: dark"
+                   (let ((org2jekyll-extra-yaml-headers "something"))
+                     (org2jekyll-tests-with-temp-buffer
+                      "#+title: hello
+#+extra-yaml-headers: theme: dark
+* one description"
+                      (org2jekyll--read-extra-yaml-headers)))))
+  (should (string= "something2"
+                   (let ((org2jekyll-extra-yaml-headers "something2"))
+                     (org2jekyll-tests-with-temp-buffer
+                      "#+title: hello
+* one description"
+                      (org2jekyll--read-extra-yaml-headers))))))

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -23,27 +23,27 @@
                    (org2jekyll-get-options-from-file temp-filename '("unknown"))))
     (should-not (org2jekyll-get-options-from-file temp-filename '()))))
 
-(ert-deftest test-org2jekyll-get-option-at-point ()
+(ert-deftest test-org2jekyll-get-option ()
   (should (equal "hello"
                  (with-temp-buffer
                    (org-mode)
                    (insert "#+HEADING: hello
 #+DATE: some-date")
                    (goto-char (point-min))
-                   (org2jekyll-get-option-at-point "HEADING"))))
+                   (org2jekyll-get-option "HEADING"))))
   (should (equal "some-date"
                  (with-temp-buffer
                    (org-mode)
                    (insert "#+HEADING: hello
 #+DATE: some-date")
                    (goto-char (point-min))
-                   (org2jekyll-get-option-at-point "DATE"))))
+                   (org2jekyll-get-option "DATE"))))
   (should-not (with-temp-buffer
                 (org-mode)
                 (insert "#+HEADING: hello
 #+DATE: some-date")
                 (goto-char (point-min))
-                (org2jekyll-get-option-at-point "UNKNOWN"))))
+                (org2jekyll-get-option "UNKNOWN"))))
 
 (ert-deftest test-org2jekyll-article-p ()
   (should (let ((temp-filename "/tmp/test-publish-article-p"))

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -614,7 +614,7 @@ Publication skipped"
   (should (eq :publish-page-done
               (with-mock
                 (mock (org2jekyll-read-metadata-and-execute
-                       'org2ekyll--publish-page-org-file-with-metadata
+                       'org2jekyll--publish-page-org-file-with-metadata
                        :org-file) => :publish-page-done)
                 (org2jekyll-publish-page :org-file)))))
 

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -129,6 +129,55 @@ excerpt: Installing jabber and using it from emacs + authentication tips and tri
                                                    ("tags"  . "\n- tag0\n- tag1\n- tag2")
                                                    ("description" . "Installing jabber and using it from emacs + authentication tips and tricks")))))))
 
+(ert-deftest test-org2jekyll--to-yaml-header-with-custom-header ()
+  ;; pre-9.0 Org releases
+  (should (string= "#+BEGIN_HTML
+---
+layout: post
+title: gtalk in emacs using jabber mode
+date: 2013-01-13
+author: Antoine R. Dumont
+categories: \n- jabber\n- emacs\n- tools\n- gtalk
+tags: \n- tag0\n- tag1\n- tag2
+excerpt: Installing jabber and using it from emacs + authentication tips and tricks
+theme: blah
+---
+#+END_HTML
+"
+                   (let ((org2jekyll-extra-yaml-headers "theme: blah"))
+                     (mocklet (((org2jekyll--old-org-version-p) => t))
+                       (org2jekyll--to-yaml-header '(("layout" . "post")
+                                                     ("title" . "gtalk in emacs using jabber mode")
+                                                     ("date" . "2013-01-13")
+                                                     ("author" . "Antoine R. Dumont")
+                                                     ("categories" . "\n- jabber\n- emacs\n- tools\n- gtalk")
+                                                     ("tags"  . "\n- tag0\n- tag1\n- tag2")
+                                                     ("description" . "Installing jabber and using it from emacs + authentication tips and tricks")))))))
+  ;; Org 9.0+ and org 8.3.x git snapshots
+  (should (string= "#+BEGIN_EXPORT HTML
+---
+layout: post
+title: gtalk in emacs using jabber mode
+date: 2013-01-13
+author: Alexey Kopytov
+categories: \n- jabber\n- emacs\n- tools\n- gtalk
+tags: \n- tag0\n- tag1\n- tag2
+excerpt: Installing jabber and using it from emacs + authentication tips and tricks
+plugin: light
+scheme-text: \"#0029ff\"
+---
+#+END_EXPORT
+"
+                   (let ((org2jekyll-extra-yaml-headers "plugin: light\nscheme-text: \"#0029ff\""))
+                     (mocklet (((org2jekyll--old-org-version-p) => nil))
+                       (org2jekyll--to-yaml-header '(("layout" . "post")
+                                                     ("title" . "gtalk in emacs using jabber mode")
+                                                     ("date" . "2013-01-13")
+                                                     ("author" . "Alexey Kopytov")
+                                                     ("categories" . "\n- jabber\n- emacs\n- tools\n- gtalk")
+                                                     ("tags"  . "\n- tag0\n- tag1\n- tag2")
+                                                     ("description" . "Installing jabber and using it from emacs + authentication tips and tricks"))))))))
+
 (ert-deftest test-org2jekyll--org-to-yaml-metadata ()
   (should (equal '(("layout" . "post")
                    ("title" . "gtalk in emacs using jabber mode")

--- a/todo.org
+++ b/todo.org
@@ -1,7 +1,8 @@
 #+title: Backlog
 #+author: ardumont
 
-* IN-PROGRESS 0.1.9 [100%]
+* DONE 0.1.9 [100%]
+CLOSED: [2016-04-16 Sat 18:36]
 - [X] Permit to add extra yaml headers during export with user-custom variable (#34)
 - [X] Support the new org-mode export block syntax with retro-compatibility (#32)
 - [X] Refactoring on internal function names

--- a/todo.org
+++ b/todo.org
@@ -1,6 +1,18 @@
 #+title: Backlog
 #+author: ardumont
 
+* IN-PROGRESS 0.1.9 [100%]
+- [X] Permit to add extra yaml headers during export with user-custom variable (#34)
+- [X] Support the new org-mode export block syntax with retro-compatibility (#32)
+- [X] Refactoring on internal function names
+- [X] Add MELPA and license badges
+- [X] Doc - Improvments (#33)
+- [X] CI - Improvments (#31)
+- [X] Packaging - Sign annotated tag during release
+- [X] Packaging - Switch to new version of evm.
+- [X] Packaging - Rename utilities.el to org2jekyll-utilities.el (#30)
+- [X] Upgrade version
+
 * DONE 0.1.8 [100%]
 CLOSED: [2015-09-06 Sun 15:44]
 - [X] Update version


### PR DESCRIPTION
- [X] Permit to add extra yaml headers during export with user-custom variable (#34)
- [X] Support the new org-mode export block syntax with retro-compatibility (#32)
- [X] Refactoring on internal function names
- [X] Add MELPA and license badges
- [X] Doc - Improvments (#33)
- [X] CI - Improvments (#31)
- [X] Packaging - Sign annotated tag during release
- [X] Packaging - Switch to new version of evm.
- [X] Packaging - Rename utilities.el to org2jekyll-utilities.el (#30)
- [X] Upgrade version