### PR TITLE
Add missing requirement for lexical-let use

### DIFF
--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -58,6 +58,7 @@
 (require 'deferred)
 (require 'ido)
 (require 'kv)
+(require 'cl-lib) ;; lexical-let
 
 (defconst org2jekyll--version "0.2.0" "Current org2jekyll version installed.")
 


### PR DESCRIPTION
It's needed only once to make a closure on the org-file to use prior to define
deferred function call.
