### PR TITLE
Respect org-mode option regarding toc generation

### DIFF
--- a/README.org
+++ b/README.org
@@ -44,6 +44,13 @@ Blogging with org-mode and jekyll without alien yaml headers.
 
 * Upgrade
 
+** 0.2.1 -> 0.2.2
+
+- The toc:t is now respected.
+- Note that org2jekyll changed internally how it's working and rely more on
+  org-mode mechanism. Notably, it uses a hook at the end of the publishing step
+  to preprend the jekyll yaml headers
+
 ** 0.2.0 -> 0.2.1
 
 - The `tags:nil` option is now respected, aligning with org-mode. So, when nil,

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -86,12 +86,10 @@
                        (org2jekyll--old-org-version-p))))
 
 (ert-deftest test-org2jekyll--to-yaml-header ()
-  ;; pre-9.0 Org releases
-  (should (string= "#+BEGIN_HTML
----
+  (should (string= "---
 layout: post
 title: gtalk in emacs using jabber mode
-date: 2013-01-13
+date: 2013-01-13 10:10
 author: Antoine R. Dumont
 categories: \n- jabber\n- emacs\n- tools\n- gtalk
 tags: \n- tag0\n- tag1\n- tag2
@@ -99,43 +97,16 @@ excerpt: Installing jabber and using it from emacs + authentication tips and tri
 comments: true
 permalink: /posts/gtalk/
 ---
-#+END_HTML
 "
-                   (mocklet (((org2jekyll--old-org-version-p) => t))
-                     (org2jekyll--to-yaml-header '(("layout" . "post")
-                                                   ("title" . "gtalk in emacs using jabber mode")
-                                                   ("date" . "2013-01-13")
-                                                   ("author" . "Antoine R. Dumont")
-                                                   ("categories" . "\n- jabber\n- emacs\n- tools\n- gtalk")
-                                                   ("tags"  . "\n- tag0\n- tag1\n- tag2")
-                                                   ("description" . "Installing jabber and using it from emacs + authentication tips and tricks")
-                                                   ("comments" . "true")
-                                                   ("permalink" . "/posts/gtalk/"))))))
-  ;; Org 9.0+ and org 8.3.x git snapshots
-  (should (string= "#+BEGIN_EXPORT HTML
----
-layout: post
-title: gtalk in emacs using jabber mode
-date: 2013-01-13
-author: Alexey Kopytov
-categories: \n- jabber\n- emacs\n- tools\n- gtalk
-tags: \n- tag0\n- tag1\n- tag2
-excerpt: Installing jabber and using it from emacs + authentication tips and tricks
-comments: true
-permalink: /posts/gtalk/
----
-#+END_EXPORT
-"
-                   (mocklet (((org2jekyll--old-org-version-p) => nil))
-                     (org2jekyll--to-yaml-header '(("layout" . "post")
-                                                   ("title" . "gtalk in emacs using jabber mode")
-                                                   ("date" . "2013-01-13")
-                                                   ("author" . "Alexey Kopytov")
-                                                   ("categories" . "\n- jabber\n- emacs\n- tools\n- gtalk")
-                                                   ("tags"  . "\n- tag0\n- tag1\n- tag2")
-                                                   ("description" . "Installing jabber and using it from emacs + authentication tips and tricks")
-                                                   ("comments" . "true")
-                                                   ("permalink" . "/posts/gtalk/")))))))
+                   (org2jekyll--to-yaml-header '(("layout" . "post")
+                                                 ("title" . "gtalk in emacs using jabber mode")
+                                                 ("date" . "2013-01-13 10:10")
+                                                 ("author" . "Antoine R. Dumont")
+                                                 ("categories" . "\n- jabber\n- emacs\n- tools\n- gtalk")
+                                                 ("tags"  . "\n- tag0\n- tag1\n- tag2")
+                                                 ("description" . "Installing jabber and using it from emacs + authentication tips and tricks")
+                                                 ("comments" . "true")
+                                                 ("permalink" . "/posts/gtalk/"))))))
 
 (ert-deftest test-org2jekyll--org-to-jekyll-metadata ()
   (should (equal '(("layout" . "post")
@@ -172,82 +143,6 @@ permalink: /posts/gtalk/
                           (fake-drafts-folder "fake-drafts-folder")
                           (org2jekyll-jekyll-drafts-dir fake-drafts-folder))
                      (org2jekyll--compute-ready-jekyll-file-name "2009-12-01" (format "/some/path/folder/%s/scratch.org" fake-drafts-folder))))))
-
-(ert-deftest test-org2jekyll--copy-org-file-to-jekyll-org-file ()
-  ;; pre-9.0 Org releases
-  (should (string= "#+BEGIN_HTML
----
-layout: post
-title: some fake title
-date: 2012-10-10
-categories: \n- some-fake-category1\n- some-fake-category2
-author: some-fake-author
-excerpt: some-fake-description with spaces and all
----
-#+END_HTML
-#+fake-meta: some fake meta
-* some content"
-                   (let ((fake-date            "2012-10-10")
-                         (fake-org-file        "/tmp/scratch.org")
-                         (fake-org-jekyll-file "/tmp/fake-org-jekyll.org"))
-                     ;; @before
-                     (when (file-exists-p fake-org-file) (delete-file fake-org-file))
-                     (when (file-exists-p fake-org-jekyll-file) (delete-file fake-org-jekyll-file))
-                     ;; @Test
-                     (mocklet (((org2jekyll--old-org-version-p) => t)
-                               ((org2jekyll--compute-ready-jekyll-file-name fake-date fake-org-file) => fake-org-jekyll-file))
-                              ;; create fake org file with some default content
-                              (with-temp-file fake-org-file
-                                (insert "#+fake-meta: some fake meta\n* some content"))
-                              ;; create the fake jekyll file with jekyll metadata
-                              (--> fake-org-file
-                                   (org2jekyll--copy-org-file-to-jekyll-org-file
-                                    fake-date it `(("layout"      . "post")
-                                                   ("title"       . "some fake title")
-                                                   ("date"        . ,fake-date)
-                                                   ("categories"  . "\n- some-fake-category1\n- some-fake-category2")
-                                                   ("author"      . "some-fake-author")
-                                                   ("description" . "some-fake-description with spaces and all")))
-                                   (insert-file-contents it)
-                                   (buffer-string)))))))
-
-(ert-deftest test-org2jekyll--copy-org-file-to-jekyll-org-file-2 ()
-  ;; Org 9.0+ and org 8.3.x git snapshots
-  (should (string= "#+BEGIN_EXPORT HTML
----
-layout: post
-title: fake title
-date: 2016-02-28
-categories: \n- fake-category1\n- fake-category2
-author: fake-author
-excerpt: fake-description with spaces and all
----
-#+END_EXPORT
-#+fake-meta: fake meta
-* some content"
-                   (let ((fake-date            "2016-02-28")
-                         (fake-org-file        "/tmp/scratch-9.0.org")
-                         (fake-org-jekyll-file "/tmp/fake-org-jekyll-9.0.org"))
-                     ;; @before
-                     (when (file-exists-p fake-org-file) (delete-file fake-org-file))
-                     (when (file-exists-p fake-org-jekyll-file) (delete-file fake-org-jekyll-file))
-                     ;; @Test
-                     (mocklet (((org2jekyll--old-org-version-p) => nil)
-                               ((org2jekyll--compute-ready-jekyll-file-name fake-date fake-org-file) => fake-org-jekyll-file))
-                       ;; create fake org file with some default content
-                       (with-temp-file fake-org-file
-                         (insert "#+fake-meta: fake meta\n* some content"))
-                       ;; create the fake jekyll file with jekyll metadata
-                       (--> fake-org-file
-                            (org2jekyll--copy-org-file-to-jekyll-org-file
-                             fake-date it `(("layout"      . "post")
-                                            ("title"       . "fake title")
-                                            ("date"        . ,fake-date)
-                                            ("categories"  . "\n- fake-category1\n- fake-category2")
-                                            ("author"      . "fake-author")
-                                            ("description" . "fake-description with spaces and all")))
-                            (insert-file-contents it)
-                            (buffer-string)))))))
 
 (ert-deftest test-org2jekyll--convert-timestamp-to-yyyy-dd-mm ()
   "Convert to simple YYYY-MM-DD date like out of either org date of iso8601 like dates"
@@ -378,16 +273,28 @@ Publication skipped" options-alist))))
                    (org2jekyll-read-metadata-and-execute (lambda (org-metadata org-file) 2) "org-file")))))
 
 (ert-deftest test-org2jekyll--publish-post-org-file-with-metadata ()
-  (should (eq :file-deleted
+  (should (eq :published-post-file
               (let ((org-publish-project-alist '((:post :project))))
                 (with-mock
-                 (mock (org2jekyll--copy-org-file-to-jekyll-org-file :date :org-file '(("layout" . :post)
-                                                                                       ("date" . :date))) => :jekyll-file)
                  (mock (org2jekyll--convert-timestamp-to-yyyy-dd-mm :date) => :date)
-                 (mock (org-publish-file :jekyll-file '(:post :project)) => :published-file)
-                 (mock (delete-file :jekyll-file) => :file-deleted)
+                 (mock (org2jekyll--compute-ready-jekyll-file-name :date :org-file) => :temp-file)
+                 (mock (copy-file :org-file :temp-file 'overwrite 'keep-time 'preserve-ids 'preserve-perms) => nil)
+                 (mock (org-publish-file :temp-file '(:post :project) 'no-cache) => :published-post-file)
                  (org2jekyll--publish-post-org-file-with-metadata '(("layout" . :post)
                                                                     ("date" . :date)) :org-file))))))
+
+(ert-deftest test-org2jekyll--publish-page-org-file-with-metadata ()
+  (should (eq :published-page-file
+              (let ((org-publish-project-alist '((:page :project)))
+                    (org2jekyll-source-directory "/path/something/"))
+                (with-mock
+                 (mock (copy-file
+                        "filename.org" "/path/something/filename.org2jekyll"
+                        'overwrite 'keep-time 'preserve-ids 'preserve-perms) => nil)
+                 (mock (org-publish-file
+                        "/path/something/filename.org2jekyll" '(:page :project) 'no-cache) => :published-page-file)
+                 (org2jekyll--publish-page-org-file-with-metadata '(("layout" . :page)
+                                                                    ("date" . :date)) "filename.org"))))))
 
 (ert-deftest test-org2jekyll-post-p ()
   "With default layouts"
@@ -621,19 +528,19 @@ Publication skipped" options-alist))))
                            :categories :some-cat)
                  (let ((org2jekyll-blog-author "dude"))
                    (with-mock
-                     (mock (org2jekyll-now) => :some-date)
-                     (mock (org2jekyll--input-read "Layout: " '("post" "default")) => :some-layout)
-                     (mock (org2jekyll--read-title) => :some-title)
-                     (mock (org2jekyll--read-description) => :some-desc)
-                     (mock (org2jekyll--read-tags) => :some-tags)
-                     (mock (org2jekyll--read-categories) => :some-cat)
-                     (org2jekyll--init-buffer-metadata))))))
+                    (mock (org2jekyll-now) => :some-date)
+                    (mock (org2jekyll--input-read "Layout: " '("post" "default")) => :some-layout)
+                    (mock (org2jekyll--read-title) => :some-title)
+                    (mock (org2jekyll--read-description) => :some-desc)
+                    (mock (org2jekyll--read-tags) => :some-tags)
+                    (mock (org2jekyll--read-categories) => :some-cat)
+                    (org2jekyll--init-buffer-metadata))))))
 
 (ert-deftest test-org2jekyll-publish-web-project ()
   (should (eq 'publish-done
               (with-mock
-                (mock (org-publish-project "web") => 'publish-done)
-                (org2jekyll-publish-web-project)))))
+               (mock (org-publish-project "web") => 'publish-done)
+               (org2jekyll-publish-web-project)))))
 
 (ert-deftest test-org2jekyll-publish-post ()
   (should (eq :publish-post-done

--- a/testing-blog/_posts/2020-05-09-blogging-with-org2jekyll.html
+++ b/testing-blog/_posts/2020-05-09-blogging-with-org2jekyll.html
@@ -1,27 +1,43 @@
 ---
-date: 2020-05-09 12:34:00
-tags:
-- blog
-- org2jekyll
-- setup
-- jekyll
+date: 2020-05-09 12:34
 author: drjekyll&mrtony
 layout: post
 title: Blogging with org2jekyll setup
 excerpt: A post demo to blog with org2jekyll
-categories:
-- blog
-- org2jekyll
-- setup
+tags: 
+- blog,
+- org2jekyll,
+- setup,
+- jekyll
+categories: 
+- blog,
+- org2jekyll,
+- setup,
 - jekyll
 ---
+<div id="table-of-contents">
+<h2>Table of Contents</h2>
+<div id="text-table-of-contents">
+<ul>
+<li><a href="#org2380597">Enter the environment</a></li>
+<li><a href="#orgae9dfdc">Setup your emacs</a>
+<ul>
+<li><a href="#org97bdcc3">Install org2jekyll</a></li>
+<li><a href="#orge28f082">Setup org2jekyll</a></li>
+</ul>
+</li>
+<li><a href="#org393257a">Create a blog post</a></li>
+<li><a href="#org46d220f">Create a static page</a></li>
+</ul>
+</div>
+</div>
 <p>
 Hello, in this post, we will show how to setup org2jekyll and play with a local
 jekyll instance.
 </p>
 
 <p>
-For this, we will be using a mix of nix tools (nix-shell) and standard
+For this, we will be using a mix of nix tools (e.g. <a href="https://nixos.wiki/wiki/Development_environment_with_nix-shell">nix-shell</a>) and standard
 Makefile. The end-goal being reproducibility.
 </p>
 
@@ -29,9 +45,9 @@ Makefile. The end-goal being reproducibility.
 Do not only trust what you read, try and reproduce it yourself following this.
 </p>
 
-<div id="outline-container-org8821387" class="outline-2">
-<h2 id="org8821387">Enter the environment</h2>
-<div class="outline-text-2" id="text-org8821387">
+<div id="outline-container-org2380597" class="outline-2">
+<h2 id="org2380597">Enter the environment</h2>
+<div class="outline-text-2" id="text-org2380597">
 <p>
 To make your environment with jekyll aware system:
 </p>
@@ -70,13 +86,13 @@ Everything should be fine and you should see a basic jekyll instance running
 </div>
 </div>
 
-<div id="outline-container-org1ce2d6f" class="outline-2">
-<h2 id="org1ce2d6f">Setup your emacs</h2>
-<div class="outline-text-2" id="text-org1ce2d6f">
+<div id="outline-container-orgae9dfdc" class="outline-2">
+<h2 id="orgae9dfdc">Setup your emacs</h2>
+<div class="outline-text-2" id="text-orgae9dfdc">
 </div>
-<div id="outline-container-org0d2bf65" class="outline-3">
-<h3 id="org0d2bf65">Install org2jekyll</h3>
-<div class="outline-text-3" id="text-org0d2bf65">
+<div id="outline-container-org97bdcc3" class="outline-3">
+<h3 id="org97bdcc3">Install org2jekyll</h3>
+<div class="outline-text-3" id="text-org97bdcc3">
 <p>
 If you do not have installed org2jekyll yet, it's fine, you can always
 temporarily activate it through emacs' buffer loading mechanism.
@@ -88,9 +104,9 @@ Open <a href="https://github.com/ardumont/org2jekyll/blob/master/org2jekyll.el">
 </div>
 </div>
 
-<div id="outline-container-orga36e4c2" class="outline-3">
-<h3 id="orga36e4c2">Setup org2jekyll</h3>
-<div class="outline-text-3" id="text-orga36e4c2">
+<div id="outline-container-orge28f082" class="outline-3">
+<h3 id="orge28f082">Setup org2jekyll</h3>
+<div class="outline-text-3" id="text-orge28f082">
 <p>
 Open <a href="https://github.com/ardumont/org2jekyll/blob/master/testing-blog/testing-blog-config.el">testing-blog-config.el</a> with emacs, load it (<b><b>M-x eval-buffer</b></b>).
 </p>
@@ -108,9 +124,9 @@ the jekyll instance.
 </div>
 </div>
 
-<div id="outline-container-orga0405a6" class="outline-2">
-<h2 id="orga0405a6">Create a blog post</h2>
-<div class="outline-text-2" id="text-orga0405a6">
+<div id="outline-container-org393257a" class="outline-2">
+<h2 id="org393257a">Create a blog post</h2>
+<div class="outline-text-2" id="text-org393257a">
 <p>
 <b><b>M-x org2jekyll-create-draft</b></b> and follow the minibuffer questions. Choose the
 layout "post" (in the current configuration).
@@ -135,9 +151,9 @@ You can loop over edition in org and publish until you are satisfied.
 </div>
 </div>
 
-<div id="outline-container-orgf5ed380" class="outline-2">
-<h2 id="orgf5ed380">Create a static page</h2>
-<div class="outline-text-2" id="text-orgf5ed380">
+<div id="outline-container-org46d220f" class="outline-2">
+<h2 id="org46d220f">Create a static page</h2>
+<div class="outline-text-2" id="text-org46d220f">
 <p>
 You can also edit static pages.
 </p>

--- a/testing-blog/org/blogging-with-org2jekyll.org
+++ b/testing-blog/org/blogging-with-org2jekyll.org
@@ -1,6 +1,6 @@
 #+STARTUP: showall
 #+STARTUP: hidestars
-#+OPTIONS: H:2 num:nil tags:nil toc:nil timestamps:t
+#+OPTIONS: H:2 num:nil tags:t toc:t timestamps:t
 #+LAYOUT: post
 #+AUTHOR: drjekyll&mrtony
 #+DATE: 2020-05-09 Sat 12:34
@@ -12,12 +12,12 @@
 Hello, in this post, we will show how to setup org2jekyll and play with a local
 jekyll instance.
 
-For this, we will be using a mix of nix tools (nix-shell) and standard
+For this, we will be using a mix of nix tools (e.g. [[https://nixos.wiki/wiki/Development_environment_with_nix-shell][nix-shell]]) and standard
 Makefile. The end-goal being reproducibility.
 
 Do not only trust what you read, try and reproduce it yourself following this.
 
-* Enter the environment
+* Enter environment
 
 To make your environment with jekyll aware system:
 #+BEGIN_SRC shell


### PR DESCRIPTION
Respect org-mode option regarding toc generation

This rewrites how org2jekyll works, relying more on org-mode's publish
mechanism to do its work.

Prior to this commit, org2jekyll manipulated temporary files to prepare jekyll
yaml header as export html black. This worked most of the time except for
example for the toc:t option which was not respected (#58).

This still does the temporary manipulation except now, we let org-mode publish
correctly the toc (and all options for that matters). Then, through a dedicated
hook, the yaml header is as the last step prepended to the html published file.

Internally, this uses emacs' hook mechanism with the dedicated org-publish hook
`org-publish-after-publishing-hook`.

When activating org2jekyll mode, this installs the hook in
'org-publish-after-publishing-hook list.

When deactivating org2jekyll mode, this removes such hook.

Related #38
