### PR TITLE
Decrease dependencies and keep only what's needed

### DIFF
--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -5,7 +5,7 @@
 ;; Author: Antoine R. Dumont (@ardumont) <antoine.romain.dumont@gmail.com>
 ;; Maintainer: Antoine R. Dumont (@ardumont) <antoine.romain.dumont@gmail.com>
 ;; Version: 0.2.4
-;; Package-Requires: ((dash-functional "2.11.0") (s "1.9.0") (deferred "0.3.1"))
+;; Package-Requires: ((dash-functional "2.11.0") (s "1.9.0"))
 ;; Keywords: org-mode jekyll blog publish
 ;; URL: https://github.com/ardumont/org2jekyll
 
@@ -55,7 +55,6 @@
 
 (require 'dash-functional)
 (require 's)
-(require 'deferred)
 (require 'ido)
 
 (defconst org2jekyll--version "0.2.4" "Current org2jekyll version installed.")
@@ -131,7 +130,7 @@ Its values are initialized according to the values defined in version <= 0.2.2."
 (defun org2jekyll--header-entry (header-entry)
   "Given a HEADER-ENTRY, format string as org-mode header."
   (let ((header-name  (-> header-entry car s-upcase))
-        (header-value (if-let (val (cadr header-entry)) val "%s")))
+        (header-value (-if-let (val (cadr header-entry)) val "%s")))
     (format "#+%s: %s" header-name header-value)))
 
 (defun org2jekyll--inline-headers (tuple-entries)
@@ -640,29 +639,21 @@ Layout `'default`' is a page (depending on the user customs)."
 
 ;;;###autoload
 (defun org2jekyll-publish-posts ()
-  "Publish all the posts."
+  "Publish all posts."
   (interactive)
-  (deferred:$
-    (deferred:next
-      (lambda () (->> (assoc org2jekyll-jekyll-layout-post org-publish-project-alist)
-                 org-publish-get-base-files
-                 (--filter (org2jekyll-post-p (org2jekyll-article-p it))))))
-    (deferred:nextc it
-      (lambda (posts)
-        (mapc #'org2jekyll-publish-post posts)))))
+  (->> (assoc org2jekyll-jekyll-layout-post org-publish-project-alist)
+       org-publish-get-base-files
+       (--filter (-> it org2jekyll-article-p org2jekyll-post-p))
+       (mapc #'org2jekyll-publish-post))  )
 
 ;;;###autoload
 (defun org2jekyll-publish-pages ()
-  "Publish all the pages."
+  "Publish all pages."
   (interactive)
-  (deferred:$
-    (deferred:next
-      (lambda () (->> (assoc org2jekyll-jekyll-layout-page org-publish-project-alist)
-                 org-publish-get-base-files
-                 (--filter (org2jekyll-page-p (org2jekyll-article-p it))))))
-    (deferred:nextc it
-      (lambda (pages)
-        (mapc #'org2jekyll-publish-page pages)))))
+  (->> (assoc org2jekyll-jekyll-layout-page org-publish-project-alist)
+       org-publish-get-base-files
+       (--filter (-> it org2jekyll-article-p org2jekyll-page-p))
+       (mapc #'org2jekyll-publish-page)))
 
 (defun org2jekyll-version ()
   "Little version helper"

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -780,4 +780,45 @@ Awesome page
                (insert-file-contents published-file)
                (buffer-substring-no-properties (point-min) (point-max)))))))
 
+(ert-deftest test-org2jekyll-publish ()
+  (should (string= "org2jekyll - published post!"
+                   (org2jekyll-tests-with-temp-buffer
+                    "#+STARTUP: showall
+#+STARTUP: hidestars
+#+OPTIONS: H:2 num:nil tags:t toc:nil timestamps:t
+#+LAYOUT: post
+#+AUTHOR: dude
+#+DATE: 2020-05-21 Thu 16:58
+#+TITLE: some-title
+#+DESCRIPTION: some-desc
+#+TAGS: some-tags
+#+CATEGORIES: some-cat
+
+Awesome post
+"
+                    (with-mock
+                      (mock (org2jekyll-publish-post nil) => "published post!")
+                      (mock (org2jekyll-publish-web-project) => 'done)
+                      (call-interactively 'org2jekyll-publish)))))
+
+  (should (string= "org2jekyll - published page!"
+                   (org2jekyll-tests-with-temp-buffer
+                    "#+STARTUP: showall
+#+STARTUP: hidestars
+#+OPTIONS: H:2 num:nil tags:t toc:nil timestamps:t
+#+LAYOUT: page
+#+AUTHOR: dude
+#+DATE: 2020-05-21 Thu 16:58
+#+TITLE: some-title
+#+DESCRIPTION: some-desc
+#+TAGS: some-tags
+#+CATEGORIES: some-cat
+
+Awesome post
+"
+                    (with-mock
+                      (mock (org2jekyll-publish-page nil) => "published page!")
+                      (mock (org2jekyll-publish-web-project) => 'done)
+                      (call-interactively 'org2jekyll-publish))))))
+
 ;;; org2jekyll-test.el ends here

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -821,4 +821,46 @@ Awesome post
                       (mock (org2jekyll-publish-web-project) => 'done)
                       (call-interactively 'org2jekyll-publish))))))
 
+(ert-deftest test-org2jekyll-publish-posts ()
+  (should (equal '("post.org")
+                 (let ((org2jekyll-jekyll-layout-post "post")
+                       (org2jekyll-jekyll-layout-page "page")
+                       (org-publish-project-alist '(("post" "something"))))
+                   (with-mock
+                     (mock (org-publish-get-base-files '("post" "something"))
+                           => '("post.org"))
+                     (mock (org2jekyll-article-p "post.org") => "post")
+                     (mock (org2jekyll-publish-post "post.org") => "post.org published!")
+                     (call-interactively 'org2jekyll-publish-posts)))))
+  (should-not (let ((org2jekyll-jekyll-layout-post "post")
+                    (org2jekyll-jekyll-layout-page "page")
+                    (org-publish-project-alist '(("post" "something"))))
+                (with-mock
+                  (mock (org-publish-get-base-files '("post" "something"))
+                        => '("page.org"))
+                  (mock (org2jekyll-article-p "page.org") => "page")
+                  (call-interactively 'org2jekyll-publish-posts)))))
+
+(ert-deftest test-org2jekyll-publish-pages ()
+  (should-not
+   (let ((org2jekyll-jekyll-layout-post "post")
+         (org2jekyll-jekyll-layout-page "page")
+         (org-publish-project-alist '(("page" "something-else"))))
+     (with-mock
+       (mock (org-publish-get-base-files '("page" "something-else"))
+             => '("post.org"))
+       (mock (org2jekyll-article-p "post.org") => "post")
+       (call-interactively 'org2jekyll-publish-pages))))
+  (should
+   (equal '("page.org")
+          (let ((org2jekyll-jekyll-layout-post "post")
+                (org2jekyll-jekyll-layout-page "page")
+                (org-publish-project-alist '(("page" "something-else"))))
+            (with-mock
+              (mock (org-publish-get-base-files '("page" "something-else"))
+                    => '("page.org"))
+              (mock (org2jekyll-article-p "page.org") => "page")
+              (mock (org2jekyll-publish-page "page.org") => "page.org published!")
+              (call-interactively 'org2jekyll-publish-pages))))))
+
 ;;; org2jekyll-test.el ends here


### PR DESCRIPTION
In the end, this PR is about removing a lot of pulled dependencies which we can avoid having.

- When publishing web project, display message when done
- Remove the lexical-let, that pulls the cl-lib namespace which makes me edgy [1]
- Remove deferred dependencies, let's the user decide if they want to defer computations
- Removing the lexical-let made the coverage drop, so i guess the coverage tool
were mislead by something pulled by lexical-let ([1] again maybe)

[1] I just cannot wrap my head around what to do about the `eval-when-compile`
and all that mess. I just want to require the module... ¯\_(ツ)_/¯
