### PR TITLE
org2jekyll-init-buffer Enhancement

### DIFF
--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -205,6 +205,7 @@ by layout, author, title, description, categories...")
   (format-time-string "%Y-%m-%d %a %H:%M"))
 
 (defun org2jekyll-default-headers-template (headers)
+  "Return an org metadata string with entries in HEADERS."
   (mapconcat #'org2jekyll--header-entry headers "\n"))
 
 (defun org2jekyll--draft-filename (draft-dir title)
@@ -235,9 +236,9 @@ by layout, author, title, description, categories...")
                        'require-match))
 
 (defun org2jekyll--init-buffer-metadata (&optional ignore-plist)
-  "Return an alist holding buffer metadata information collected from the user.
+  "Return an plist holding buffer metadata information collected from the user.
 Any non-nil property in IGNORE-PLIST will not be collected from the user, and
-will instead have its value in the alist set as nil."
+will instead have its value omitted in the returned plist."
   (-concat (unless (plist-get ignore-plist :author)
 	     (list :author org2jekyll-blog-author))
 	   (unless (plist-get ignore-plist :date)

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -422,28 +422,25 @@ Publication skipped" options-alist))))
                      (when (file-exists-p "/tmp/some-title.org")
                        (delete-file "/tmp/some-title.org"))
                      ;; Define extra headers
-                     (custom-set-variables
-                      '(org2jekyll-default-template-entries-extra '(("theme" "dark")
-                                                                    ("comments" "false"))))
-                     ;; execute draft creation
-                     (save-excursion
-                       (let ((org2jekyll-source-directory "/tmp")
-                             (org2jekyll-jekyll-drafts-dir "")
-                             (org2jekyll-blog-author "tony"))
-                         (with-mock
-                          (mock (org2jekyll-now)                                                        => "some date")
-                          (mock (ido-completing-read "Layout: " '("post" "default") nil 'require-match) => "post")
-                          (mock (org2jekyll--read-title)                                                => "some title")
-                          (mock (org2jekyll--read-description)                                          => "some description")
-                          (mock (org2jekyll--read-tags)                                                 => "tag0 tag1")
-                          (mock (org2jekyll--read-categories)                                           => "cat0 cat1 catn")
-                          (mock (org2jekyll-input-directory "")                                         => "/tmp")
-                          (mock (org2jekyll--draft-filename * *)                                        => "/tmp/some-title.org")
-                          (mock (find-file "/tmp/some-title.org") => nil)
-                          (call-interactively #'org2jekyll-create-draft))))
-                     ;; Revert extra headers (common to all tests ¯\_(ツ)_/¯)
-                     (custom-set-variables
-                      '(org2jekyll-default-template-entries-extra nil))
+		     (let ((org2jekyll-default-template-entries-extra
+			    '(("theme" "dark")
+			      ("comments" "false"))))
+		       ;; execute draft creation
+		       (save-excursion
+			 (let ((org2jekyll-source-directory "/tmp")
+			       (org2jekyll-jekyll-drafts-dir "")
+			       (org2jekyll-blog-author "tony"))
+			   (with-mock
+			    (mock (org2jekyll-now)                                                        => "some date")
+			    (mock (ido-completing-read "Layout: " '("post" "default") nil 'require-match) => "post")
+			    (mock (org2jekyll--read-title)                                                => "some title")
+			    (mock (org2jekyll--read-description)                                          => "some description")
+			    (mock (org2jekyll--read-tags)                                                 => "tag0 tag1")
+			    (mock (org2jekyll--read-categories)                                           => "cat0 cat1 catn")
+			    (mock (org2jekyll-input-directory "")                                         => "/tmp")
+			    (mock (org2jekyll--draft-filename * *)                                        => "/tmp/some-title.org")
+			    (mock (find-file "/tmp/some-title.org") => nil)
+			    (call-interactively #'org2jekyll-create-draft)))))
                      ;; read the created file
                      (with-temp-buffer
                        (insert-file-contents "/tmp/some-title.org")
@@ -469,7 +466,7 @@ Publication skipped" options-alist))))
 * already present
 "
                     (with-mock
-                     (mock (org2jekyll--init-buffer-metadata) => '(:author "dude"
+                     (mock (org2jekyll--init-buffer-metadata *) => '(:author "dude"
                                                                            :date "some-date"
                                                                            :layout "some-layout"
                                                                            :title "some-title"

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -475,6 +475,27 @@ Publication skipped" options-alist))))
                                                                            :description "some-desc"
                                                                            :tags "some-tags"
                                                                            :categories "some-cat"))
+                     (call-interactively #'org2jekyll-init-current-buffer)))))
+  (should (string= "#+TITLE: already-present-title
+#+STARTUP: showall
+#+STARTUP: hidestars
+#+OPTIONS: H:2 num:nil tags:t toc:nil timestamps:t
+#+LAYOUT: some-layout
+#+AUTHOR: dude
+#+DATE: some-date
+#+DESCRIPTION: some-desc
+#+TAGS: some-tags
+#+CATEGORIES: some-cat
+"
+                   (org2jekyll-tests-with-temp-buffer-and-return-content
+                    "#+TITLE: already-present-title"
+                    (with-mock
+                     (mock (org2jekyll--init-buffer-metadata *) => '(:author "dude"
+                                                                           :date "some-date"
+                                                                           :layout "some-layout"
+                                                                           :description "some-desc"
+                                                                           :tags "some-tags"
+                                                                           :categories "some-cat"))
                      (call-interactively #'org2jekyll-init-current-buffer))))))
 
 


### PR DESCRIPTION
Hi! `org2jekyll-init-buffer` now checks for existing metadata, and doesn't prompt the user if required metadata is found. Any new metadata is added after this existing metadata.

I've also changed some existing customization options to make it possible:  format strings are no longer pre-created, metadata strings are created on the fly by `org2jekyll--get-template-entries`. The order entries appear in the metadata is determined by their ordering in `org2jekyll-default-template-entries` and `org2jekyll-default-template-entries-extra` (entries in the former appearing before entries in the latter).

I've added tests for any new functions (I think I've not forgot any).

If you have any questions or reservations, I'd be happy to answer them, Cheers ~ Laurence.