### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -5,7 +5,7 @@
 ;; Author: Antoine R. Dumont (@ardumont) <antoine.romain.dumont@gmail.com>
 ;; Maintainer: Antoine R. Dumont (@ardumont) <antoine.romain.dumont@gmail.com>
 ;; Version: 0.2.7
-;; Package-Requires: ((dash-functional "2.11.0") (s "1.9.0"))
+;; Package-Requires: ((dash "2.18.0") (s "1.9.0"))
 ;; Keywords: org-mode jekyll blog publish
 ;; URL: https://github.com/ardumont/org2jekyll
 
@@ -53,7 +53,7 @@
 (require 'org)
 (require (if (version< emacs-version "24.4") 'org-publish 'ox-publish))
 
-(require 'dash-functional)
+(require 'dash)
 (require 's)
 (require 'ido)
 

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ with import <nixpkgs> {};
 let sources = import ./nix/sources.nix;
     pkgs = import sources.nixpkgs {};
     org2jekyll-emacs = emacsWithPackages (epkgs: (with epkgs.melpaStablePackages; [
-      dash-functional
+      dash
       s
       htmlize
     ]));


### PR DESCRIPTION
### Rapid summary

Dash 2.18.0 now subsumes `dash-functional`, which is deprecated; see https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218

### What issue does this fix or improve?

It removes this package's dependency on the now deprecated `dash-functional` library, and replaces it with the newest version of `dash` which now includes all of the old definitions from `dash-functional`.

While in the area, this PR also formalises the existing dependency on Emacs `24.3+` in the package's `Package-Requires` header.

### Have you checked and/or added tests?

No.