### PR TITLE
Fix Option Messaged as Missing Edge Case

### DIFF
--- a/org2jekyll.el
+++ b/org2jekyll.el
@@ -311,7 +311,7 @@ The specified title will be used as the name of the file."
 
 (defun org2jekyll-get-options-from-buffer ()
   "Return special lines at the beginning of current buffer."
-  (let ((special-line-regex "^#\\+\\(.+\\):[ \t]+\\(.+\\)$")
+  (let ((special-line-regex "^#\\+\\(.+\\):[ \t]+\\(.*\\)$")
         (get-current-line (lambda ()
                             (buffer-substring-no-properties (line-beginning-position)
                                                             (line-end-position))))
@@ -320,13 +320,15 @@ The specified title will be used as the name of the file."
       (goto-char (point-min))
       (catch 'break
         (while (string-match special-line-regex (funcall get-current-line))
-          (setq options-plist (plist-put options-plist
-                                         (->> (funcall get-current-line)
-                                              (match-string 1)
-                                              downcase
-                                              (concat ":")
-                                              intern)
-                                         (match-string 2 (funcall get-current-line))))
+          (let ((current-line (funcall get-current-line)))
+            (unless (s-blank-str-p (match-string 2 current-line))
+              (setq options-plist (plist-put options-plist
+                                             (->> current-line
+                                               (match-string 1)
+                                               downcase
+                                               (concat ":")
+                                               intern)
+                                             (match-string 2 current-line)))))
           (unless (= 0 (forward-line))
             (throw 'break nil))))
       options-plist)))

--- a/test/org2jekyll-test.el
+++ b/test/org2jekyll-test.el
@@ -16,7 +16,19 @@
                                                           "Beef fungus articles"))
                                           (org2jekyll-get-options-from-buffer))))
     (should (string= blog-val (plist-get options-plist :blog)))
-    (should (string= date-val (plist-get options-plist :date)))))
+    (should (string= date-val (plist-get options-plist :date))))
+  (let* ((description-key "#+DESCRIPTION:")
+         (description-val "")
+         (categories-key "#+CATEGORIES:")
+         (categories-val "some-category")
+         (options-plist
+          (with-temp-buffer
+            (insert (concat description-key " " description-val "\n"
+                            categories-key " " categories-val "\n"
+                            "Beef fungus articles"))
+            (org2jekyll-get-options-from-buffer))))
+    (should-not (plist-get options-plist :description))
+    (should (string= categories-val (plist-get options-plist :categories)))))
 
 (ert-deftest test-org2jekyll-get-options-from-file ()
   (let* ((temp-file "/tmp/test-get-options-from-file")


### PR DESCRIPTION
### Rapid summary

This PR fixes the edge case of some options being messaged as missing when they are specified.

### What issue does this fix or improve?

With:
```org
#+TITLE: title
#+STARTUP: showall
#+STARTUP: hidestars
#+OPTIONS: H:2 num:nil tags:t toc:nil timestamps:t
#+LAYOUT: post
#+AUTHOR: Laurence Warne
#+DATE: 2021-07-30 Fri 19:48
#+DESCRIPTION: 
#+CATEGORIES: my-category
#+TAGS: my-tag
```

`M-x org2jekyll-publish` messages:

```
org2jekyll - org2jekyll - This org-mode file is missing required header(s):
- The categories is required, please add ’#+CATEGORIES’ at the top of your org buffer.
- The description is required, please add ’#+DESCRIPTION’ at the top of your org buffer.
```

When only description is not specified.  This PR hopes to solve this by tweaking the special line regex so it accepts options with empty values, but `org2jekyll-get-options-from-buffer` just doesn't add them the option plist, so that the option parsing is not ended prematurely.

### Have you checked and/or added tests?

I've added a test for a watered down version of the above example.

Thanks!